### PR TITLE
chore: rm continue-on-error

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -47,4 +47,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true
-        continue-on-error: true

--- a/.github/workflows/contract-storage-diff.yaml
+++ b/.github/workflows/contract-storage-diff.yaml
@@ -6,7 +6,6 @@ jobs:
   check-migration:
     name: Check Valid Migration File Exists
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
removes unnecessary `continue-on-error`