### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2059,7 +2059,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-axelar-example"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "goldie",
  "soroban-token-sdk",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "stellar-axelar-operators"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "cfg-if",
  "goldie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ proc-macro2 = { version = "1.0", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 serde = { version = "1.0.152", default-features = false, features = ["derive"] }
 soroban-token-sdk = { version = "22.0.6" }
-stellar-axelar-example = { version = "^1.0.0", path = "contracts/stellar-axelar-example" }
+stellar-axelar-example = { version = "^1.0.1", path = "contracts/stellar-axelar-example" }
 stellar-axelar-gas-service = { version = "^1.1.0", path = "contracts/stellar-axelar-gas-service" }
 stellar-axelar-gateway = { version = "^1.1.0", path = "contracts/stellar-axelar-gateway" }
-stellar-axelar-operators = { version = "^1.0.0", path = "contracts/stellar-axelar-operators" }
+stellar-axelar-operators = { version = "^1.1.0", path = "contracts/stellar-axelar-operators" }
 stellar-axelar-std = { version = "^1.1.0", path = "packages/stellar-axelar-std", features = ["derive"] }
 stellar-axelar-std-derive = { version = "^1.1.0", path = "packages/stellar-axelar-std-derive" }
 stellar-interchain-token = { version = "^1.1.0", path = "contracts/stellar-interchain-token" }

--- a/contracts/stellar-axelar-example/Cargo.toml
+++ b/contracts/stellar-axelar-example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stellar-axelar-example"
-version = "1.0.0"
+version = "1.0.1"
 edition = { workspace = true }
 description = "AxelarExample contract, responsible for demonstrating interchain message and token transfers with Gateway, GasService, and InterchainTokenService."
 license = { workspace = true }

--- a/contracts/stellar-axelar-operators/CHANGELOG.md
+++ b/contracts/stellar-axelar-operators/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/axelarnetwork/axelar-amplifier-stellar/compare/stellar-axelar-operators-v1.0.0...stellar-axelar-operators-v1.1.0)
+
+### ⛰️ Features
+
+- Block regular contract endpoints during migration ([#279](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/279)) - ([7444057](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/7444057f85f73ff8a65eedbd5ae0aad77c2e7ad4))
+- Add only_owner and only_operator macros ([#240](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/240)) - ([bf26705](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/bf267059dd047475c7efb7e9bee47b40eaec4bbd))
+
+### 🐛 Bug Fixes
+
+- *(axelar-std-derive)* Enforce contractstorage enums are private ([#267](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/267)) - ([b9c5688](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/b9c568830c5207f68104bf9c9156e0c851722b98))
+- Update compile gh action to build and test all contracts separately ([#322](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/322)) - ([f6d3623](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/f6d3623d79655a9f48dbb1db77f48aa08545b651))
+- Remove redundant ttl extensions ([#259](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/259)) - ([573ea7b](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/573ea7bbbaa2811e9d569c810dd5988c3f3e5d2b))
+- Avoid ignoring dead_code warnings ([#257](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/257)) - ([05c4b8a](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/05c4b8ae47cdf8383dad5fd2b29f9dbe6fcc9026))
+
+### 🚜 Refactor
+
+- *(axelar-operators)* Remove soroban-sdk ([#293](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/293)) - ([2775c37](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/2775c37139bd900ff64024adaf6fc76c7823a21c))
+- *(axelar-operators)* Migrate Operators to Operator ([#252](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/252)) - ([dc76cb3](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/dc76cb3b6b11f13e906c54d1179c2fa157a4449d))
+- *(axelar-operators)* Rename Operators status to Operator ([#249](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/249)) - ([319cd74](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/319cd74f6123bfbeaa1f8f425bc52e639d4926b7))
+- *(axelar-operators)* Use contractstorage ([#244](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/244)) - ([aa1f167](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/aa1f16704d1d2841b0e382443d8b1b42db341f3d))
+- *(axelar-std-derive)* Simplify upgradable macro ([#256](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/256)) - ([e5fee26](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/e5fee262c1ff0a848a94d4a4109c45901283dcc7))
+- Move the run_migration function into a clearly defined interface ([#239](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/239)) - ([7bd306d](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/7bd306d9d2d4f1045814decd569188c29486d924))
+
+### 📚 Documentation
+
+- Fix docs publish action ([#236](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/236)) - ([cbbc410](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/cbbc41005435baf20809c892b196f468c55b84d1))
+
+### ⚙️ Miscellaneous Tasks
+
+- Remove all unused derive macros ([#258](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/258)) - ([46a36d5](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/46a36d57359bc1a4854261f88953f6f40d399b51))
+
+### Contributors
+
+* @ahramy
+* @cgorenflo
+* @nbayindirli
+* @TanvirDeol
+* @milapsheth
+
 ## [1.0.0](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-axelar-operators-v0.2.3...stellar-axelar-operators-v1.0.0)
 
 ### ⚙️ Miscellaneous Tasks

--- a/contracts/stellar-axelar-operators/Cargo.toml
+++ b/contracts/stellar-axelar-operators/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stellar-axelar-operators"
-version = "1.0.0"
+version = "1.1.0"
 edition = { workspace = true }
 description = "AxelarOperators contract, responsible for managing operators and enabling invoking functions with access control and upgradeability."
 license = { workspace = true }

--- a/contracts/stellar-multicall/CHANGELOG.md
+++ b/contracts/stellar-multicall/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0]
+
+### ⛰️ Features
+
+- *(multicall)* Create multicall contract ([#277](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/277)) - ([d3bdac0](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/d3bdac05e39b5bed98dcf11841d8d8b0a99561a5))
+
+### Contributors
+
+* @TanvirDeol


### PR DESCRIPTION


### [1.0.0]

Package: stellar-axelar-example 1.0.0 -> 1.0.1

Changes:
### ⛰️ Features

- *(example)* Rename axelar example ([#270](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/270)) - ([970fcec](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/970fcec38fd2e324cc924f7a66c88b7382190561))
- Block regular contract endpoints during migration ([#279](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/279)) - ([7444057](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/7444057f85f73ff8a65eedbd5ae0aad77c2e7ad4))
- Add custom executable interface for AxelarExecutableInterface for ease of use ([#265](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/265)) - ([53103fe](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/53103febaab2bf0c5e9a1a7df4f38336e0a4f50d))

### 🐛 Bug Fixes

- *(axelar-example)* Remove unused pause state variable ([#300](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/300)) - ([f80bdd9](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/f80bdd9f6ef2e516762af5f4b97aed8b841e17a4))
- Rename its token address and manager queries ([#273](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/273)) - ([f696af5](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/f696af50dc1bd1b6d1d4db1ae7f588c8ea43976f))

### 🚜 Refactor

- *(axelar-example)* Remove soroban-sdk ([#288](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/288)) - ([fe25923](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/fe25923db923d52a9eececab47f47cf32aeeb350))

### ⚙️ Miscellaneous Tasks

- Update auth invocation macros ([#269](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/269)) - ([8161812](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/816181212d2cf9c4794f4faf5c754f0832047092))

### Contributors

* @ahramy
* @cgorenflo
* @TanvirDeol



### [1.1.0](https://github.com/axelarnetwork/axelar-amplifier-stellar/compare/stellar-axelar-operators-v1.0.0...stellar-axelar-operators-v1.1.0)

Package: stellar-axelar-operators 1.0.0 -> 1.1.0

Changes:
### ⛰️ Features

- Block regular contract endpoints during migration ([#279](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/279)) - ([7444057](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/7444057f85f73ff8a65eedbd5ae0aad77c2e7ad4))
- Add only_owner and only_operator macros ([#240](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/240)) - ([bf26705](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/bf267059dd047475c7efb7e9bee47b40eaec4bbd))

### 🐛 Bug Fixes

- *(axelar-std-derive)* Enforce contractstorage enums are private ([#267](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/267)) - ([b9c5688](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/b9c568830c5207f68104bf9c9156e0c851722b98))
- Update compile gh action to build and test all contracts separately ([#322](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/322)) - ([f6d3623](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/f6d3623d79655a9f48dbb1db77f48aa08545b651))
- Remove redundant ttl extensions ([#259](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/259)) - ([573ea7b](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/573ea7bbbaa2811e9d569c810dd5988c3f3e5d2b))
- Avoid ignoring dead_code warnings ([#257](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/257)) - ([05c4b8a](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/05c4b8ae47cdf8383dad5fd2b29f9dbe6fcc9026))

### 🚜 Refactor

- *(axelar-operators)* Remove soroban-sdk ([#293](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/293)) - ([2775c37](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/2775c37139bd900ff64024adaf6fc76c7823a21c))
- *(axelar-operators)* Migrate Operators to Operator ([#252](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/252)) - ([dc76cb3](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/dc76cb3b6b11f13e906c54d1179c2fa157a4449d))
- *(axelar-operators)* Rename Operators status to Operator ([#249](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/249)) - ([319cd74](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/319cd74f6123bfbeaa1f8f425bc52e639d4926b7))
- *(axelar-operators)* Use contractstorage ([#244](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/244)) - ([aa1f167](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/aa1f16704d1d2841b0e382443d8b1b42db341f3d))
- *(axelar-std-derive)* Simplify upgradable macro ([#256](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/256)) - ([e5fee26](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/e5fee262c1ff0a848a94d4a4109c45901283dcc7))
- Move the run_migration function into a clearly defined interface ([#239](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/239)) - ([7bd306d](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/7bd306d9d2d4f1045814decd569188c29486d924))

### 📚 Documentation

- Fix docs publish action ([#236](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/236)) - ([cbbc410](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/cbbc41005435baf20809c892b196f468c55b84d1))

### ⚙️ Miscellaneous Tasks

- Remove all unused derive macros ([#258](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/258)) - ([46a36d5](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/46a36d57359bc1a4854261f88953f6f40d399b51))

### Contributors

* @ahramy
* @cgorenflo
* @nbayindirli
* @TanvirDeol
* @milapsheth



### [1.0.0]

Package: stellar-multicall 1.0.0 -> 1.0.0

Changes:
### ⛰️ Features

- *(multicall)* Create multicall contract ([#277](https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/277)) - ([d3bdac0](https://github.com/axelarnetwork/axelar-amplifier-stellar/commit/d3bdac05e39b5bed98dcf11841d8d8b0a99561a5))

### Contributors

* @TanvirDeol

