### PR TITLE
fix(release): add rust tool chain

### DIFF
--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -23,6 +23,9 @@ jobs:
         with:
           token: ${{ secrets.PAT_TOKEN }}
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Get commit hash
         id: get-commit-hash
         run: echo "hash=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,9 @@ jobs:
         with:
           token: ${{ secrets.PAT_TOKEN }}
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Get commit hash
         id: get-commit-hash
         run: echo "hash=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
A fix for the release error: https://github.com/axelarnetwork/axelar-amplifier-stellar/actions/runs/14321545102/job/40139292869

```
error: failed to verify package tarball
    
    Caused by:
      rustc 1.80.0 is not supported by the following packages:
        alloy-primitives@0.8.25 requires rustc 1.81
        alloy-sol-macro@0.8.25 requires rustc 1.81
        alloy-sol-macro-expander@0.8.25 requires rustc 1.81
        alloy-sol-macro-input@0.8.25 requires rustc 1.81
        alloy-sol-types@0.8.25 requires rustc 1.81
        syn-solidity@0.8.25 requires rustc 1.81
    
Error: Process completed with exit code 1.
```