### PR TITLE
feat(stellar-token-utils): add stellar asset contract address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,6 +2190,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellar-token-utils"
+version = "1.0.0"
+dependencies = [
+ "cfg-if",
+ "goldie",
+ "stellar-axelar-std",
+]
+
+[[package]]
 name = "stellar-upgrader"
 version = "1.1.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ stellar-axelar-std-derive = { version = "^1.1.2", path = "packages/stellar-axela
 stellar-interchain-token = { version = "^1.1.2", path = "contracts/stellar-interchain-token" }
 stellar-interchain-token-service = { version = "^1.2.0", path = "contracts/stellar-interchain-token-service" }
 stellar-token-manager = { version = "^1.1.2", path = "contracts/stellar-token-manager" }
+stellar-token-utils = { version = "^1.0.0", path = "contracts/stellar-token-utils" }
 stellar-multicall = { version = "^1.0.2", path = "contracts/stellar-multicall" }
 stellar-upgrader = { version = "^1.1.2", path = "contracts/stellar-upgrader" }
 

--- a/contracts/stellar-token-utils/Cargo.toml
+++ b/contracts/stellar-token-utils/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "stellar-token-utils"
+version = "1.0.0"
+edition = "2021"
+description = "Utility functions for Stellar assets"
+license = { workspace = true }
+publish = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+cfg-if = { workspace = true }
+stellar-axelar-std = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+goldie = { workspace = true }
+stellar-axelar-std = { workspace = true, features = ["testutils"] }
+
+[features]
+library = [] # Exports only the contract interface
+testutils = ["stellar-axelar-std/testutils"]
+
+[lints]
+workspace = true

--- a/contracts/stellar-token-utils/src/contract.rs
+++ b/contracts/stellar-token-utils/src/contract.rs
@@ -1,0 +1,75 @@
+use stellar_axelar_std::address::AddressExt;
+use stellar_axelar_std::xdr::{
+    AccountId, AlphaNum12, AlphaNum4, Asset as XdrAsset, AssetCode12, AssetCode4, Limits,
+    PublicKey, WriteXdr,
+};
+use stellar_axelar_std::{
+    contract, contractimpl, ensure, soroban_sdk, Address, Bytes, Env, String,
+};
+
+use crate::error::ContractError;
+use crate::interface::StellarTokenUtilsInterface;
+use crate::r#macro::{address_to_account_id, string_to_asset_code};
+
+#[contract]
+pub struct StellarTokenUtils;
+
+#[contractimpl]
+impl StellarTokenUtils {
+    pub fn __constructor(_env: &Env) {}
+
+    /// Private method to create asset XDR representation
+    fn create_asset_xdr(
+        &self,
+        env: &Env,
+        code: &String,
+        issuer: &Address,
+    ) -> Result<Bytes, ContractError> {
+        // Validate code length - Stellar asset codes must be 12 characters or less
+        if code.len() > 12 {
+            return Err(ContractError::InvalidAssetCode);
+        }
+
+        let asset = {
+            // Convert issuer address to AccountId using macro
+            let issuer_account_id = address_to_account_id!(issuer);
+
+            if code.len() <= 4 {
+                let code_array = string_to_asset_code!(code, 4);
+                XdrAsset::CreditAlphanum4(AlphaNum4 {
+                    asset_code: AssetCode4(code_array),
+                    issuer: issuer_account_id,
+                })
+            } else {
+                let code_array = string_to_asset_code!(code, 12);
+                XdrAsset::CreditAlphanum12(AlphaNum12 {
+                    asset_code: AssetCode12(code_array),
+                    issuer: issuer_account_id,
+                })
+            }
+        };
+
+        let xdr_bytes = asset
+            .to_xdr(Limits::none())
+            .map_err(|_| ContractError::InvalidAssetCode)?;
+        Ok(Bytes::from_slice(env, &xdr_bytes))
+    }
+}
+
+#[contractimpl]
+impl StellarTokenUtilsInterface for StellarTokenUtils {
+    fn stellar_asset_contract_address(
+        env: Env,
+        code: String,
+        issuer: Address,
+    ) -> Result<Address, ContractError> {
+        ensure!(!code.is_empty(), ContractError::InvalidAssetCode);
+
+        let serialized_asset = Self.create_asset_xdr(&env, &code, &issuer)?;
+
+        let deployer = env.deployer().with_stellar_asset(serialized_asset);
+        let sac_address = deployer.deployed_address();
+
+        Ok(sac_address)
+    }
+}

--- a/contracts/stellar-token-utils/src/error.rs
+++ b/contracts/stellar-token-utils/src/error.rs
@@ -1,0 +1,10 @@
+use stellar_axelar_std::{contracterror, soroban_sdk};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ContractError {
+    MigrationNotAllowed = 1,
+    MigrationInProgress = 2,
+    InvalidAssetCode = 3,
+}

--- a/contracts/stellar-token-utils/src/interface.rs
+++ b/contracts/stellar-token-utils/src/interface.rs
@@ -1,0 +1,12 @@
+use stellar_axelar_std::{contractclient, soroban_sdk, Address, Env, String};
+
+use crate::error::ContractError;
+
+#[contractclient(name = "StellarTokenUtilsClient")]
+pub trait StellarTokenUtilsInterface {
+    fn stellar_asset_contract_address(
+        env: Env,
+        code: String,
+        issuer: Address,
+    ) -> Result<Address, ContractError>;
+}

--- a/contracts/stellar-token-utils/src/lib.rs
+++ b/contracts/stellar-token-utils/src/lib.rs
@@ -1,0 +1,26 @@
+#![no_std]
+
+#[cfg(any(test, feature = "testutils"))]
+#[macro_use]
+extern crate std;
+
+mod error;
+mod r#macro;
+
+#[cfg(test)]
+mod tests;
+
+cfg_if::cfg_if! {
+    if #[cfg(all(feature = "library", not(test)))] {
+        mod interface;
+        pub use interface::StellarTokenUtilsInterface;
+    } else {
+        mod interface;
+        mod contract;
+
+        pub use contract::{StellarTokenUtils, StellarTokenUtilsClient};
+        pub use interface::StellarTokenUtilsInterface;
+    }
+}
+
+pub use error::ContractError;

--- a/contracts/stellar-token-utils/src/macro.rs
+++ b/contracts/stellar-token-utils/src/macro.rs
@@ -1,0 +1,30 @@
+/// Macro to convert an Address to an AccountId for XDR serialization
+macro_rules! address_to_account_id {
+    ($issuer:expr) => {{
+        let issuer_bytes = $issuer.to_raw_bytes();
+        let mut issuer_key_bytes = [0u8; 32];
+
+        // Extract the public key part (last 32 bytes)
+        if issuer_bytes.len() >= 32 {
+            issuer_key_bytes.copy_from_slice(&issuer_bytes[issuer_bytes.len() - 32..]);
+        }
+
+        let public_key = PublicKey::PublicKeyTypeEd25519(issuer_key_bytes.into());
+        AccountId(public_key)
+    }};
+}
+
+/// Macro to convert a String to a fixed-size asset code array
+macro_rules! string_to_asset_code {
+    ($code:expr, $size:expr) => {{
+        let mut code_array = [0u8; $size];
+        let code_len = $code.len() as usize;
+        let mut code_buffer = [0u8; 32];
+        $code.copy_into_slice(&mut code_buffer[..code_len]);
+        let copy_len = code_len.min($size);
+        code_array[..copy_len].copy_from_slice(&code_buffer[..copy_len]);
+        code_array
+    }};
+}
+
+pub(crate) use {address_to_account_id, string_to_asset_code};

--- a/contracts/stellar-token-utils/src/tests/mod.rs
+++ b/contracts/stellar-token-utils/src/tests/mod.rs
@@ -1,0 +1,3 @@
+#![cfg(test)]
+
+mod test;

--- a/contracts/stellar-token-utils/src/tests/test.rs
+++ b/contracts/stellar-token-utils/src/tests/test.rs
@@ -1,0 +1,243 @@
+use std::vec::Vec;
+
+use stellar_axelar_std::{Address, Env, String};
+
+use crate::StellarTokenUtils;
+
+fn create_test_issuer(env: &Env) -> Address {
+    // Use proper Stellar address starting with G
+    Address::from_string(&String::from_str(
+        env,
+        "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+    ))
+}
+
+fn create_test_issuer_2(env: &Env) -> Address {
+    // Use proper Stellar address starting with G
+    Address::from_string(&String::from_str(
+        env,
+        "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI",
+    ))
+}
+
+fn create_test_issuer_3(env: &Env) -> Address {
+    // Another test issuer
+    Address::from_string(&String::from_str(
+        env,
+        "GC57ZJLYGUOMGDGPD5XFDOTQHQER3QL6B72SPTR3XTEKRY3HJ75NCNBL",
+    ))
+}
+
+fn setup_contract(env: &Env) -> crate::StellarTokenUtilsClient {
+    let contract_id = env.register(StellarTokenUtils, ());
+    crate::StellarTokenUtilsClient::new(env, &contract_id)
+}
+
+// Helper function to test successful cases
+fn assert_success(
+    env: &Env,
+    client: &crate::StellarTokenUtilsClient,
+    code: &str,
+    issuer: &Address,
+) -> Address {
+    let code_string = String::from_str(env, code);
+    let result = client.try_stellar_asset_contract_address(&code_string, issuer);
+    assert!(result.is_ok(), "Failed for code: {}", code);
+    result.unwrap().unwrap()
+}
+
+// Helper function to test error cases
+fn assert_error(env: &Env, client: &crate::StellarTokenUtilsClient, code: &str, issuer: &Address) {
+    let code_string = String::from_str(env, code);
+    let result = client.try_stellar_asset_contract_address(&code_string, issuer);
+    assert!(result.is_err(), "Expected error for code: {}", code);
+}
+
+#[test]
+fn test_stellar_asset_contract_address_basic_functionality() {
+    let env = Env::default();
+    let client = setup_contract(&env);
+    let issuer = create_test_issuer(&env);
+
+    // Test various valid codes
+    let valid_codes = vec!["USDC", "BTC", "ETH", "USD", "A", "ABC", "ABCDEFGHIJKL"];
+
+    for code in valid_codes {
+        assert_success(&env, &client, code, &issuer);
+    }
+}
+
+#[test]
+fn test_stellar_asset_contract_address_native_assets() {
+    let env = Env::default();
+    let client = setup_contract(&env);
+    let issuer = create_test_issuer(&env);
+
+    // Test native asset variants
+    let native_codes = vec!["XLM", "native"];
+
+    for code in native_codes {
+        assert_success(&env, &client, code, &issuer);
+    }
+}
+
+#[test]
+fn test_stellar_asset_contract_address_error_cases() {
+    let env = Env::default();
+    let client = setup_contract(&env);
+    let issuer = create_test_issuer(&env);
+
+    // Test error cases
+    let error_codes = vec![
+        "",                                            // Empty code
+        "ABCDEFGHIJKLM",                               // 13 characters
+        "FOURTEENCHAR12",                              // 14 characters
+        "THISISAVERYLONGASSETCODETHATEXCEEDSTHELIMIT", // Extremely long
+    ];
+
+    for code in error_codes {
+        assert_error(&env, &client, code, &issuer);
+    }
+}
+
+#[test]
+fn test_stellar_asset_contract_address_length_boundaries() {
+    let env = Env::default();
+    let client = setup_contract(&env);
+    let issuer = create_test_issuer(&env);
+
+    // Test all valid lengths (1-12 characters)
+    let valid_lengths = vec![
+        "A",            // 1 char
+        "AB",           // 2 chars
+        "ABC",          // 3 chars
+        "ABCD",         // 4 chars (AlphaNum4 boundary)
+        "ABCDE",        // 5 chars (AlphaNum12 starts)
+        "ABCDEF",       // 6 chars
+        "ABCDEFG",      // 7 chars
+        "ABCDEFGH",     // 8 chars
+        "ABCDEFGHI",    // 9 chars
+        "ABCDEFGHIJ",   // 10 chars
+        "ABCDEFGHIJK",  // 11 chars
+        "ABCDEFGHIJKL", // 12 chars (maximum)
+    ];
+
+    let mut addresses = Vec::new();
+    for code in &valid_lengths {
+        addresses.push(assert_success(&env, &client, code, &issuer));
+    }
+
+    // All addresses should be different
+    for i in 0..addresses.len() {
+        for j in i + 1..addresses.len() {
+            assert_ne!(
+                addresses[i], addresses[j],
+                "Addresses should be different for codes '{}' and '{}'",
+                valid_lengths[i], valid_lengths[j]
+            );
+        }
+    }
+
+    // Test invalid lengths
+    assert_error(&env, &client, "ABCDEFGHIJKLM", &issuer); // 13 chars
+    assert_error(&env, &client, "ABCDEFGHIJKLMN", &issuer); // 14 chars
+}
+
+#[test]
+fn test_stellar_asset_contract_address_deterministic_behavior() {
+    let env = Env::default();
+    let client = setup_contract(&env);
+    let issuer = create_test_issuer(&env);
+    let code = "CONSISTENT";
+
+    // Multiple calls should return identical addresses
+    let addresses: Vec<Address> = (0..5)
+        .map(|_| assert_success(&env, &client, code, &issuer))
+        .collect();
+
+    // All addresses should be identical
+    for i in 1..addresses.len() {
+        assert_eq!(addresses[0], addresses[i], "Deterministic behavior failed");
+    }
+}
+
+#[test]
+fn test_stellar_asset_contract_address_different_inputs() {
+    let env = Env::default();
+    let client = setup_contract(&env);
+
+    let issuer1 = create_test_issuer(&env);
+    let issuer2 = create_test_issuer_2(&env);
+    let issuer3 = create_test_issuer_3(&env);
+
+    // Test different codes with same issuer
+    let codes = vec!["USD", "EUR", "GBP"];
+    let mut code_addresses = Vec::new();
+    for code in &codes {
+        code_addresses.push(assert_success(&env, &client, code, &issuer1));
+    }
+
+    // Test same code with different issuers
+    let same_code = "STABLE";
+    let issuer_addresses = vec![
+        assert_success(&env, &client, same_code, &issuer1),
+        assert_success(&env, &client, same_code, &issuer2),
+        assert_success(&env, &client, same_code, &issuer3),
+    ];
+
+    // All addresses should be different
+    let all_addresses = [code_addresses, issuer_addresses].concat();
+    for i in 0..all_addresses.len() {
+        for j in i + 1..all_addresses.len() {
+            assert_ne!(
+                all_addresses[i], all_addresses[j],
+                "All addresses should be unique"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_stellar_asset_contract_address_alphanumeric_variants() {
+    let env = Env::default();
+    let client = setup_contract(&env);
+    let issuer = create_test_issuer(&env);
+
+    // Test different character types
+    let test_cases = vec![
+        ("USDC", "Standard alphabetic"),
+        ("123", "Numeric only"),
+        ("USD2024", "Mixed alphanumeric"),
+        ("USDC", "Uppercase"),
+        ("usdc", "Lowercase"),
+    ];
+
+    let mut addresses = Vec::new();
+    for (code, description) in &test_cases {
+        let addr = assert_success(&env, &client, code, &issuer);
+        addresses.push((addr, description));
+    }
+
+    // USDC and usdc should produce different addresses (case sensitive)
+    assert_ne!(
+        addresses[3].0, addresses[4].0,
+        "Case sensitivity should produce different addresses"
+    );
+}
+
+#[test]
+fn test_stellar_asset_contract_address_alphanum_type_boundary() {
+    let env = Env::default();
+    let client = setup_contract(&env);
+    let issuer = create_test_issuer(&env);
+
+    // Test the boundary between AlphaNum4 and AlphaNum12
+    let alphanum4_code = assert_success(&env, &client, "ABCD", &issuer); // 4 chars
+    let alphanum12_code = assert_success(&env, &client, "ABCDE", &issuer); // 5 chars
+
+    // Should produce different addresses due to different asset types
+    assert_ne!(
+        alphanum4_code, alphanum12_code,
+        "AlphaNum4 and AlphaNum12 should produce different addresses"
+    );
+}


### PR DESCRIPTION
**cargo test:**

```
running 8 tests
test tests::test::test_stellar_asset_contract_address_native_assets ... ok
test tests::test::test_stellar_asset_contract_address_alphanum_type_boundary ... ok
test tests::test::test_stellar_asset_contract_address_deterministic_behavior ... ok
test tests::test::test_stellar_asset_contract_address_error_cases ... ok
test tests::test::test_stellar_asset_contract_address_alphanumeric_variants ... ok
test tests::test::test_stellar_asset_contract_address_different_inputs ... ok
test tests::test::test_stellar_asset_contract_address_basic_functionality ... ok
test tests::test::test_stellar_asset_contract_address_length_boundaries ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


```

**stellar contract build:**
```
error[E0432]: unresolved import `stellar_axelar_std::xdr::Limits`
 --> contracts/stellar-token-utils/src/contract.rs:3:83
  |
3 |     AccountId, AlphaNum12, AlphaNum4, Asset as XdrAsset, AssetCode12, AssetCode4, Limits,
  |                                                                                   ^^^^^^ no `Limits` in `xdr`

warning: unused import: `WriteXdr`
 --> contracts/stellar-token-utils/src/contract.rs:4:16
  |
4 |     PublicKey, WriteXdr,
  |                ^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

error[E0599]: no method named `to_xdr` found for enum `stellar_axelar_std::xdr::Asset` in the current scope
  --> contracts/stellar-token-utils/src/contract.rs:53:14
   |
52 |           let xdr_bytes = asset
   |  _________________________-
53 | |             .to_xdr(Limits::none())
   | |             -^^^^^^ method not found in `Asset`
   | |_____________|
   |

Some errors have detailed explanations: E0432, E0599.
For more information about an error, try `rustc --explain E0432`.
warning: `stellar-token-utils` (lib) generated 1 warning
error: could not compile `stellar-token-utils` (lib) due to 2 previous errors; 1 warning emitted
❌ error: exit status exit status: 101

```