### PR TITLE
feat(interchain-token): add token manager to interchain token

### DIFF
--- a/contracts/stellar-interchain-token/src/contract.rs
+++ b/contracts/stellar-interchain-token/src/contract.rs
@@ -157,14 +157,6 @@ impl InterchainTokenInterface for InterchainToken {
     #[only_owner]
     fn set_token_manager(env: &Env, token_manager: Address) {
         storage::set_token_manager(env, &token_manager);
-
-        if !Self::is_minter(env, token_manager.clone()) {
-            storage::set_minter_status(env, token_manager.clone());
-            MinterAddedEvent {
-                minter: token_manager,
-            }
-            .emit(env);
-        }
     }
 
     fn token_manager(env: &Env) -> Address {

--- a/contracts/stellar-interchain-token/src/interface.rs
+++ b/contracts/stellar-interchain-token/src/interface.rs
@@ -51,4 +51,19 @@ pub trait InterchainTokenInterface:
     /// # Authorization
     /// - [`OwnableInterface::owner`] must authorize.
     fn remove_minter(env: &Env, minter: Address);
+
+    /// Sets the token manager as a minter for this interchain token.
+    ///
+    /// # Arguments
+    /// * `token_manager` - The address of the token manager to be set as a minter.
+    ///
+    /// # Authorization
+    /// - [`OwnableInterface::owner`] must authorize.
+    fn set_token_manager(env: &Env, token_manager: Address);
+
+    /// Returns the address of the token manager for this interchain token.
+    ///
+    /// # Returns
+    /// - `Address` - The address of the token manager.
+    fn token_manager(env: &Env) -> Address;
 }

--- a/contracts/stellar-interchain-token/src/storage.rs
+++ b/contracts/stellar-interchain-token/src/storage.rs
@@ -31,4 +31,8 @@ enum DataKey {
     #[instance]
     #[value(BytesN<32>)]
     TokenId,
+
+    #[instance]
+    #[value(Address)]
+    TokenManager,
 }

--- a/contracts/stellar-interchain-token/src/testdata/ensure_data_key_storage_schema_is_unchanged.golden
+++ b/contracts/stellar-interchain-token/src/testdata/ensure_data_key_storage_schema_is_unchanged.golden
@@ -16,4 +16,8 @@ enum DataKey {
     #[instance]
     #[value(BytesN<32>)]
     TokenId,
+
+    #[instance]
+    #[value(Address)]
+    TokenManager,
 }

--- a/contracts/stellar-interchain-token/src/tests/test.rs
+++ b/contracts/stellar-interchain-token/src/tests/test.rs
@@ -721,7 +721,6 @@ fn set_token_manager_succeeds() {
     assert_auth!(token.owner(), token.set_token_manager(&new_token_manager));
 
     assert_eq!(token.token_manager(), new_token_manager.clone());
-    assert!(token.is_minter(&new_token_manager));
 }
 
 #[test]

--- a/contracts/stellar-interchain-token/src/tests/test.rs
+++ b/contracts/stellar-interchain-token/src/tests/test.rs
@@ -336,18 +336,18 @@ fn mint_succeeds() {
 
     let (token, _) = setup_token(&env);
 
-    // Token manager (which is the owner initially) can mint
-    let token_manager = token.token_manager();
-    assert_eq!(token_manager, token.owner());
-
-    assert_auth!(token_manager, token.mint(&user, &amount));
+    assert_auth!(token.owner(), token.mint(&user, &amount));
 
     goldie::assert!(fmt_last_emitted_event::<MintEvent>(&env));
 
     assert_eq!(token.balance(&user), amount);
 
-    // Token manager can always mint (since it's the designated minter for the mint function)
-    assert_auth!(token_manager, token.mint(&user, &amount));
+    if token.is_minter(&token.owner()) {
+        token.mock_all_auths().remove_minter(&token.owner());
+    }
+
+    // Owner can mint without being a minter
+    assert_auth!(token.owner(), token.mint(&user, &amount));
     assert_eq!(token.balance(&user), amount * 2);
 }
 
@@ -714,8 +714,6 @@ fn allowance_preserves_expiration_when_expired() {
 #[test]
 fn set_token_manager_succeeds() {
     let env = Env::default();
-    let amount = 1000;
-    let user = Address::generate(&env);
     let new_token_manager = Address::generate(&env);
     let (token, _) = setup_token(&env);
     assert_eq!(token.token_manager(), token.owner());
@@ -724,9 +722,6 @@ fn set_token_manager_succeeds() {
 
     assert_eq!(token.token_manager(), new_token_manager.clone());
     assert!(token.is_minter(&new_token_manager));
-
-    assert_auth!(new_token_manager, token.mint(&user, &amount));
-    assert_eq!(token.balance(&user), amount);
 }
 
 #[test]
@@ -737,6 +732,20 @@ fn set_token_manager_fails_without_owner_auth() {
     let (token, _) = setup_token(&env);
 
     assert_auth_err!(user, token.set_token_manager(&new_token_manager));
+}
+
+#[test]
+fn mint_succeeds_with_new_token_manager() {
+    let env = Env::default();
+    let amount = 1000;
+    let user = Address::generate(&env);
+    let new_token_manager = Address::generate(&env);
+    let (token, _) = setup_token(&env);
+
+    assert_auth!(token.owner(), token.set_token_manager(&new_token_manager));
+
+    assert_auth!(new_token_manager, token.mint(&user, &amount));
+    assert_eq!(token.balance(&user), amount);
 }
 
 #[test]

--- a/contracts/stellar-interchain-token/src/tests/test.rs
+++ b/contracts/stellar-interchain-token/src/tests/test.rs
@@ -720,7 +720,7 @@ fn set_token_manager_succeeds() {
 
     assert_auth!(token.owner(), token.set_token_manager(&new_token_manager));
 
-    assert_eq!(token.token_manager(), new_token_manager.clone());
+    assert_eq!(token.token_manager(), new_token_manager);
 }
 
 #[test]
@@ -744,6 +744,7 @@ fn mint_succeeds_with_new_token_manager() {
     assert_auth!(token.owner(), token.set_token_manager(&new_token_manager));
 
     assert_auth!(new_token_manager, token.mint(&user, &amount));
+
     assert_eq!(token.balance(&user), amount);
 }
 


### PR DESCRIPTION
- add token manager to interchain token
- `mint` is being called from token manager instead of owner (initially the owner and token manager are the same)